### PR TITLE
LDMIOTrack: Fix crashes after file read failed.

### DIFF
--- a/LDMIOTrack.java
+++ b/LDMIOTrack.java
@@ -92,7 +92,7 @@ public class LDMIOTrack implements ILDMIOHandler {
 			ois.close();
 			fis.close();
 		}
-		if (!isFileValid) {
+		if (!isFileValid || gpspath == null || markers == null) {
 			gpspath = new ArrayList<GpsPoint>();
 			markers = new ArrayList<Marker>();
 		}


### PR DESCRIPTION
Ensures that gpspath and markers are never null pointers.
Lots of code using them assumes they aren't.

Signed-off-by: Reimar Döffinger Reimar.Doeffinger@gmx.de
