### PR TITLE
One more getOrthogonal fix.

### DIFF
--- a/GpsPoint.java
+++ b/GpsPoint.java
@@ -69,8 +69,9 @@ public class GpsPoint implements Serializable {
 	}
 
 	public GpsPoint getOrthogonal(GpsPoint origin) {
-		  double xnew = origin.longitude - (latitude - origin.latitude);
-		  double ynew = origin.latitude + (longitude - origin.longitude);
+		  double lon_scale = Math.cos(origin.latitude);
+		  double xnew = origin.longitude - (latitude - origin.latitude) / lon_scale;
+		  double ynew = origin.latitude + (longitude - origin.longitude) * lon_scale;
 		  
 		  return new GpsPoint(xnew, ynew, this.time);
 	}


### PR DESCRIPTION
We need to take into account that longitude to
read distance scales with cos(latitude).
Otherwise both angles and distances will be all wrong
after rotation.

Signed-off-by: Reimar Döffinger Reimar.Doeffinger@gmx.de
