### PR TITLE
Remove broken repairBrockenMarkers.

### DIFF
--- a/LDMIOTrack.java
+++ b/LDMIOTrack.java
@@ -41,20 +41,6 @@ public class LDMIOTrack implements ILDMIOHandler {
 	long time;
 	
 	/**
-	 * Resets all the markers GpsPoints to the timely closest GpsPoints in track.
-	 */
-	private void repairBrockenMarkers() {
-		for (Marker m : markers) {
-			for (int index = 0; index < gpspath.size(); index++) {
-				if(gpspath.get(index).time > m.time) {
-					m.realpoint = gpspath.get(index);
-					break;
-				}
-			}
-		}
-	}
-	
-	/**
 	 * Reads track format.
 	 */
 	@SuppressWarnings("unchecked")
@@ -65,7 +51,6 @@ public class LDMIOTrack implements ILDMIOHandler {
 			case 3:
 				gpspath = (ArrayList<GpsPoint>) ois.readObject();
 				markers = (ArrayList<Marker>) ois.readObject();
-				repairBrockenMarkers();
 				break;
 			default:
 				System.err.println("Unknown file version number: "


### PR DESCRIPTION
First, I see little value of hacking up the markers
the user specified manually after the fact.
Doubly so when it happens on the next reload, which
means at a random future point.
Further, if a marker and GPS point have the same
timestamp that would be a good reason to connect them,
but that is in fact not done.
Markers are connected with the following GPS point.
Which results in complete nonsense results when the
scenario is: GPS is acquired, markers is set, GPS signal
is lost, GPS signal is restored at a completely different
location.
Then the marker will be associated with this completely
different location.
This seems likely to explain and fix a lot of random failures
in MapEver.

Signed-off-by: Reimar Döffinger Reimar.Doeffinger@gmx.de
