### PR TITLE
Take bitmap y axis orientation into account for getOrthogonal.

### DIFF
--- a/Point2D.java
+++ b/Point2D.java
@@ -43,8 +43,9 @@ public class Point2D implements Serializable {
 	}
 	
 	public Point2D getOrthogonal(Point2D origin) { 
-		double xnew = origin.x - (y - origin.y);
-		double ynew = origin.y + (x - origin.x);
+		// Turn opposite to GPS as y axis goes down, not up
+		double xnew = origin.x + (y - origin.y);
+		double ynew = origin.y - (x - origin.x);
 		return new Point2D(xnew, ynew);
 	}
 	


### PR DESCRIPTION
Larger numbers are down, thus we must flip the rotate
compared to how be rotate GPS in corresponding function.
I have some hope I've finally reached a fully working state...
Why oh why do these coordinate systems have to be so messed up?
GPS usually has latitude first e.g. in geo: URLs, but everything else tends to have X first, bitmaps have the y axis go down, OpenGL and GPS have it go "up", what a mess...
